### PR TITLE
fix: 修复插入点数量为1时,extent值为0的异常现象 && 修复 alloc-dealloc-mismatch，即分配和释放内存时…

### DIFF
--- a/octree2/Octree.h
+++ b/octree2/Octree.h
@@ -388,7 +388,7 @@ namespace thuni
 					if(child[i] != 0)
 						delete child[i];
 				}
-				delete child;
+				delete[] child;
 				child = nullptr;
 			}
 			else
@@ -575,6 +575,7 @@ namespace thuni
 			points.resize(cloud_index); // 删除多余元素
 			float ctr[3] = {min[0], min[1], min[2]};
 			float maxextent = 0.5f * (max[0] - min[0]);
+			maxextent = std::max(maxextent, 0.01f);
 			ctr[0] += maxextent;
 			for (size_t i = 1; i < 3; ++i)
 			{
@@ -1013,6 +1014,7 @@ namespace thuni
 			points.resize(cloud_index); // 删除多余元素
 			float ctr[3] = {min[0], min[1], min[2]};
 			float maxextent = 0.5f * (max[0] - min[0]);
+			maxextent = std::max(maxextent, 0.01f);
 			ctr[0] += maxextent;
 			for (size_t i = 1; i < 3; ++i)
 			{


### PR DESCRIPTION
- hello 首先非常感谢您开源这项工作，我们在实际项目中使用了您的开源算法，性能较之前方案有明显提升，非常感谢。
- 但我们实际使用中发现了以下两个问题：

1. 某个key 中仅有一个点时，此时计算出来的extent值为0，后续向该key所在的ioctree中插入点时，将导致算法一直卡在update_record函数的while循环中，电脑会直接卡死。
2. 另外在使用asan工具分析内存时发现，出现alloc-dealloc-mismatch相关错误 ，经分析确定是 child使用new[]分配内存，但释放未使用delete[]释放内存，而是用成了delete

- =54666==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x60600011be80
    #0 0x7ffff7662c65 in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cc:177
    #1 0x5555556533ac in thuni::Octant::~Octant() Octree.h:313
    #2 0x55555565334d in thuni::Octant::~Octant() Octree.h:311
    #3 0x55555565334d in thuni::Octant::~Octant() Octree.h:311
    #4 0x55555565334d in thuni::Octant::~Octant() Octree.h:311
    #5 0x55555565334d in thuni::Octant::~Octant() Octree.h:311
    #6 0x5555556539d5 in thuni::Octree::clear() Octree.h:603
    #7 0x55555565396f in thuni::Octree::~Octree() Octree.h:417
    #8 0x55555566f28b in std::default_delete<thuni::Octree>::operator()(thuni::Octree*) const /usr/include/c++/9/bits/unique_ptr.h:81
